### PR TITLE
Lda gleason

### DIFF
--- a/LogReg_gleason/LogReg_GS.py
+++ b/LogReg_gleason/LogReg_GS.py
@@ -1,8 +1,25 @@
 from sklearn.linear_model import LogisticRegression
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+lda = LinearDiscriminantAnalysis(solver='svd',
+                                 shrinkage=None,
+                                 priors=None,
+                                 n_components=1,
+                                 store_covariance=False,
+                                 tol=0.0001)
+lda.fit(X_train,y_train)
+Xlda_train = lda.transform(X_train)
+Xlda_test = lda.transform(X_test)
+
+
 gleason_train = gleason.loc[y_train.index]
 gleason_test = gleason.loc[y_test.index]
 gleason_train = gleason_train.reshape(-1,1)
 gleason_test = gleason_test.reshape(-1,1)
+
+logisticDF = pd.DataFrame({'lda_transform' : Xlda_train[:,0],
+                           'gleason_scores' : gleason_train[:,0]}, index = y_train.index)
+logisticDF_test = pd.DataFrame({'lda_transform' : Xlda_test[:,0],
+                                'gleason_scores' : gleason_test[:,0]}, index = y_test.index)
 
 estimator = LogisticRegression(penalty='l2',
                               dual=False,
@@ -29,11 +46,11 @@ clf = GridSearchCV(estimator,
                    verbose=0,
                    pre_dispatch='2*n_jobs',
                    error_score='raise')
-clf.fit(gleason_train, y_train)
-Gleason_LR_clf = clf.best_estimator_
-print(Gleason_LR_clf)
+clf.fit(logisticDF, y_train)
+LR_clf = clf.best_estimator_
+print(LR_clf)
 print(classification_report(y_train,
-                            clf.predict(gleason_train),
+                            LR_clf.predict(logisticDF),
                             target_names = ['n0', 'n1']))
-print('\nF beta: ', fbeta_score(y_train, Gleason_LR_clf.predict(gleason_train), beta = 2, pos_label='n1'))
-print('\nMCC: ',matthews_corrcoef(y_train, Gleason_LR_clf.predict(gleason_train)))
+print('\nF beta: ', fbeta_score(y_train, LR_clf.predict(logisticDF), beta = 2, pos_label='n1'))
+print('\nMCC: ',matthews_corrcoef(y_train, LR_clf.predict(logisticDF)))

--- a/PCa_Metastasis.ipynb
+++ b/PCa_Metastasis.ipynb
@@ -580,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 113,
    "metadata": {
     "collapsed": false
    },
@@ -607,7 +607,7 @@
     "from sklearn.svm import SVC\n",
     "clf = SVC(C=1,\n",
     "          kernel='linear',\n",
-    "          probability=False,\n",
+    "          probability=True,\n",
     "          tol=0.001,\n",
     "          cache_size=200,\n",
     "          gamma = 'auto',\n",
@@ -632,7 +632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 111,
    "metadata": {
     "collapsed": false
    },
@@ -654,7 +654,7 @@
       "           dtype='int64')\n",
       "SVC(C=0.5, cache_size=200, class_weight='balanced', coef0=0.0,\n",
       "  decision_function_shape=None, degree=3, gamma='auto', kernel='linear',\n",
-      "  max_iter=-1, probability=False, random_state=123, shrinking=True,\n",
+      "  max_iter=-1, probability=True, random_state=123, shrinking=True,\n",
       "  tol=0.001, verbose=False)\n"
      ]
     }
@@ -665,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 112,
    "metadata": {
     "collapsed": false
    },
@@ -812,6 +812,90 @@
    ],
    "source": [
     "%run -i LogReg_gleason/LogReg_GS.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   Proba   y\n",
+      "clinical_index              \n",
+      "TCGA-VN-A88R    0.110008  n0\n",
+      "TCGA-EJ-5515    0.200722  n0\n",
+      "TCGA-J4-A67M    0.019065  n0\n",
+      "TCGA-EJ-5518    0.564571  n0\n",
+      "TCGA-EJ-AB20    0.101532  n0\n",
+      "TCGA-CH-5794    0.153026  n0\n",
+      "TCGA-QU-A6IL    0.040074  n0\n",
+      "TCGA-V1-A9O9    0.150041  n0\n",
+      "TCGA-EJ-5509    0.076678  n0\n",
+      "TCGA-HC-7752    0.062036  n0\n",
+      "TCGA-CH-5746    0.083274  n0\n",
+      "TCGA-ZG-A9L5    0.994319  n1\n",
+      "TCGA-EJ-5494    0.109687  n0\n",
+      "TCGA-G9-7525    0.077656  n0\n",
+      "TCGA-KK-A6E4    0.062177  n0\n",
+      "TCGA-KK-A8I7    0.492989  n0\n",
+      "TCGA-V1-A9OX    0.121641  n0\n",
+      "TCGA-V1-A9O7    0.168988  n0\n",
+      "TCGA-HC-7210    0.162148  n0\n",
+      "TCGA-EJ-8472    0.310200  n0\n",
+      "TCGA-KK-A6E3    0.036527  n0\n",
+      "TCGA-YL-A9WJ    0.045002  n1\n",
+      "TCGA-EJ-7784    0.202605  n0\n",
+      "TCGA-KK-A8IB    0.384344  n0\n",
+      "TCGA-CH-5752    0.104421  n0\n",
+      "TCGA-G9-6348    0.080775  n0\n",
+      "TCGA-HC-A76X    0.051792  n0\n",
+      "TCGA-XK-AAJU    0.297125  n0\n",
+      "TCGA-HC-7737    0.004657  n1\n",
+      "TCGA-VP-A87K    0.487470  n0\n",
+      "...                  ...  ..\n",
+      "TCGA-EJ-A7NH    0.303710  n0\n",
+      "TCGA-KK-A6E1    0.985842  n1\n",
+      "TCGA-KC-A4BL    0.317410  n0\n",
+      "TCGA-HC-7209    0.012942  n0\n",
+      "TCGA-YL-A8SQ    0.142274  n0\n",
+      "TCGA-V1-A9ZI    0.141884  n0\n",
+      "TCGA-V1-A9OL    0.220742  n0\n",
+      "TCGA-KK-A8I8    0.357677  n0\n",
+      "TCGA-J4-A67L    0.095001  n0\n",
+      "TCGA-HC-A6AL    0.478193  n0\n",
+      "TCGA-KK-A7B0    0.116114  n0\n",
+      "TCGA-WW-A8ZI    0.067976  n0\n",
+      "TCGA-CH-5766    0.967034  n1\n",
+      "TCGA-YL-A8SC    0.399646  n0\n",
+      "TCGA-EJ-A8FN    0.098576  n0\n",
+      "TCGA-CH-5754    0.945509  n1\n",
+      "TCGA-KK-A7AV    0.377046  n0\n",
+      "TCGA-G9-6369    0.044797  n0\n",
+      "TCGA-CH-5741    0.914463  n1\n",
+      "TCGA-KK-A8I9    0.445477  n0\n",
+      "TCGA-HC-7078    0.109423  n0\n",
+      "TCGA-HI-7168    0.415061  n0\n",
+      "TCGA-HC-A9TE    0.176043  n0\n",
+      "TCGA-VP-A878    0.801205  n1\n",
+      "TCGA-CH-5768    0.020275  n0\n",
+      "TCGA-EJ-7792    0.009689  n0\n",
+      "TCGA-CH-5788    0.966260  n1\n",
+      "TCGA-EJ-A7NM    0.982722  n1\n",
+      "TCGA-SU-A7E7    0.319121  n0\n",
+      "TCGA-EJ-5504    0.180211  n1\n",
+      "\n",
+      "[353 rows x 2 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pd.DataFrame({'Proba' : LR_clf.predict_proba(logisticDF)[:,1],\n",
+    "                   'y': y_train}))"
    ]
   },
   {
@@ -1002,7 +1086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 114,
    "metadata": {
     "collapsed": false
    },
@@ -1017,9 +1101,9 @@
     "    weights = []\n",
     "    for model in clf_dict.items() :\n",
     "        #print(model[0])\n",
-    "        df[model[0]] = model[1]['model'].predict(model[1]['input_set'])\n",
+    "        df[model[0]] = model[1]['model'].predict_proba(model[1]['input_set'])[:,1]\n",
     "        #index = model[1]['label_set'].index\n",
-    "        df[model[0]].replace({'n1':1,'n0':0}, inplace = True)\n",
+    "        #df[model[0]].replace({'n1':1,'n0':0}, inplace = True)\n",
     "        df[model[0]] = df[model[0]].apply(lambda x : x*model[1]['weight'])\n",
     "        weights.append(model[1]['weight'])\n",
     "    df.set_index(clf_dict['SVM']['label_set'].index, inplace=True)\n",
@@ -1035,53 +1119,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 115,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                AdaBoost  Random_Forest  LogReg   SVM  Weighted_Vote actual_y  \\\n",
-      "clinical_index                                                                  \n",
-      "TCGA-HC-7078         0.0            0.0    0.00  0.00           0.00       n0   \n",
-      "TCGA-HI-7168         0.1            0.0    0.00  0.00           0.10       n0   \n",
-      "TCGA-HC-A9TE         0.1            0.2    0.00  0.35           0.65       n0   \n",
-      "TCGA-VP-A878         0.1            0.0    0.35  0.35           0.80       n1   \n",
-      "TCGA-CH-5768         0.0            0.0    0.00  0.00           0.00       n0   \n",
-      "TCGA-EJ-7792         0.0            0.0    0.00  0.00           0.00       n0   \n",
-      "TCGA-CH-5788         0.0            0.0    0.35  0.35           0.70       n1   \n",
-      "TCGA-EJ-A7NM         0.1            0.2    0.35  0.35           1.00       n1   \n",
-      "TCGA-SU-A7E7         0.1            0.0    0.00  0.35           0.45       n0   \n",
-      "TCGA-EJ-5504         0.0            0.0    0.00  0.00           0.00       n1   \n",
-      "\n",
-      "               called_y  \n",
-      "clinical_index           \n",
-      "TCGA-HC-7078         n0  \n",
-      "TCGA-HI-7168         n0  \n",
-      "TCGA-HC-A9TE         n1  \n",
-      "TCGA-VP-A878         n1  \n",
-      "TCGA-CH-5768         n0  \n",
-      "TCGA-EJ-7792         n0  \n",
-      "TCGA-CH-5788         n1  \n",
-      "TCGA-EJ-A7NM         n1  \n",
-      "TCGA-SU-A7E7         n0  \n",
-      "TCGA-EJ-5504         n0  \n",
-      "\n",
-      "MCC:  0.791771275197\n",
-      "\n",
-      "F beta:  0.867647058824\n",
-      "\n",
-      "Class_report:\n",
-      "               precision    recall  f1-score   support\n",
-      "\n",
-      "         n0       0.97      0.94      0.96       287\n",
-      "         n1       0.78      0.89      0.83        66\n",
-      "\n",
-      "avg / total       0.94      0.93      0.93       353\n",
-      "\n"
+     "ename": "AttributeError",
+     "evalue": "predict_proba is not available when  probability=False",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m/Users/ccthomps/Documents/Python Files/Udacity Projects/capstone/RFE_SVM/RFECV_SVM.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mvoter\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mclf_dict\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/ccthomps/Documents/Python Files/Udacity Projects/capstone/RFE_SVM/RFECV_SVM.py\u001b[0m in \u001b[0;36mvoter\u001b[0;34m(clf_dict)\u001b[0m\n\u001b[1;32m      8\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mmodel\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mclf_dict\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m         \u001b[0;31m#print(model[0])\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m         \u001b[0mdf\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'model'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict_proba\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'input_set'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m         \u001b[0;31m#index = model[1]['label_set'].index\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m         \u001b[0;31m#df[model[0]].replace({'n1':1,'n0':0}, inplace = True)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/ccthomps/anaconda/lib/python3.5/site-packages/sklearn/svm/base.py\u001b[0m in \u001b[0;36mpredict_proba\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    604\u001b[0m         \u001b[0mdatasets\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    605\u001b[0m         \"\"\"\n\u001b[0;32m--> 606\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_proba\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    607\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_predict_proba\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    608\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/ccthomps/anaconda/lib/python3.5/site-packages/sklearn/svm/base.py\u001b[0m in \u001b[0;36m_check_proba\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    571\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_check_proba\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    572\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprobability\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 573\u001b[0;31m             raise AttributeError(\"predict_proba is not available when \"\n\u001b[0m\u001b[1;32m    574\u001b[0m                                  \" probability=False\")\n\u001b[1;32m    575\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_impl\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m'c_svc'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'nu_svc'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: predict_proba is not available when  probability=False"
      ]
     }
    ],

--- a/PCa_Metastasis.ipynb
+++ b/PCa_Metastasis.ipynb
@@ -769,12 +769,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Logistic Regression for Gleason Scores"
+    "### Logistic Regression"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 62,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -790,56 +790,17 @@
       "          solver='liblinear', tol=0.0001, verbose=0, warm_start=False)\n",
       "             precision    recall  f1-score   support\n",
       "\n",
-      "         n0       0.94      0.62      0.75       287\n",
-      "         n1       0.33      0.82      0.47        66\n",
+      "         n0       0.97      0.96      0.96       287\n",
+      "         n1       0.83      0.86      0.84        66\n",
       "\n",
-      "avg / total       0.82      0.66      0.70       353\n",
+      "avg / total       0.94      0.94      0.94       353\n",
       "\n",
       "\n",
-      "F beta:  0.633802816901\n",
+      "F beta:  0.855855855856\n",
       "\n",
-      "MCC:  0.345731022783\n"
+      "MCC:  0.807994294106\n"
      ]
-    }
-   ],
-   "source": [
-    "%run -i LogReg_gleason/LogReg_GS.py"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Linear Discriminant Analysis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from sklearn.discriminant_analysis import LinearDiscriminantAnalysis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -847,50 +808,10 @@
       "/Users/ccthomps/anaconda/lib/python3.5/site-packages/sklearn/discriminant_analysis.py:387: UserWarning: Variables are collinear.\n",
       "  warnings.warn(\"Variables are collinear.\")\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "LinearDiscriminantAnalysis(n_components=1, priors=None, shrinkage=None,\n",
-       "              solver='svd', store_covariance=False, tol=0.0001)"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "lda = LinearDiscriminantAnalysis(solver='svd', \n",
-    "                                 shrinkage=None, \n",
-    "                                 priors=None, \n",
-    "                                 n_components=1, \n",
-    "                                 store_covariance=False, \n",
-    "                                 tol=0.0001)\n",
-    "lda.fit(X_train,y_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MCC:  0.845826929128\n",
-      "F beta:  0.817610062893\n"
-     ]
-    }
-   ],
-   "source": [
-    "Xlda_train = lda.transform(X_train)\n",
-    "pred_lda = lda.predict(X_train)\n",
-    "print('MCC: ',matthews_corrcoef(y_train, pred_lda))\n",
-    "print('F beta: ', fbeta_score(y_train, pred_lda, beta = 2, pos_label='n1'))"
+    "%run -i LogReg_gleason/LogReg_GS.py"
    ]
   },
   {
@@ -905,7 +826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 64,
    "metadata": {
     "collapsed": false
    },
@@ -916,54 +837,22 @@
      "text": [
       "             precision    recall  f1-score   support\n",
       "\n",
-      "         n0       0.88      0.98      0.93        58\n",
-      "         n1       0.83      0.38      0.53        13\n",
+      "         n0       0.93      0.95      0.94        58\n",
+      "         n1       0.75      0.69      0.72        13\n",
       "\n",
-      "avg / total       0.87      0.87      0.85        71\n",
+      "avg / total       0.90      0.90      0.90        71\n",
       "\n",
-      "MCC:  0.510812825044\n",
-      "F beta:  0.431034482759\n"
+      "F beta:  0.703125\n",
+      "MCC:  0.661066012033\n"
      ]
     }
    ],
    "source": [
     "print(classification_report(y_test,\n",
-    "                            lda.predict(X_test),\n",
+    "                            LR_clf.predict(logisticDF_test),\n",
     "                            target_names = ['n0', 'n1']))\n",
-    "\n",
-    "print('MCC: ',matthews_corrcoef(y_test, lda.predict(X_test)))\n",
-    "print('F beta: ', fbeta_score(y_test, lda.predict(X_test), beta = 2, pos_label='n1'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "             precision    recall  f1-score   support\n",
-      "\n",
-      "         n0       0.95      0.67      0.79        58\n",
-      "         n1       0.37      0.85      0.51        13\n",
-      "\n",
-      "avg / total       0.84      0.70      0.74        71\n",
-      "\n",
-      "F beta:  0.670731707317\n",
-      "MCC:  0.406011681267\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(classification_report(y_test,\n",
-    "                            Gleason_LR_clf.predict(gleason_test),\n",
-    "                            target_names = ['n0', 'n1']))\n",
-    "print('F beta: ', fbeta_score(y_test, Gleason_LR_clf.predict(gleason_test), beta = 2, pos_label='n1'))\n",
-    "print('MCC: ',matthews_corrcoef(y_test, Gleason_LR_clf.predict(gleason_test)))"
+    "print('F beta: ', fbeta_score(y_test, LR_clf.predict(logisticDF_test), beta = 2, pos_label='n1'))\n",
+    "print('MCC: ',matthews_corrcoef(y_test, LR_clf.predict(logisticDF_test)))"
    ]
   },
   {
@@ -1071,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 80,
    "metadata": {
     "collapsed": false
    },
@@ -1080,97 +969,44 @@
     "clf_dict = {'AdaBoost' : {'model': ada_clf, \n",
     "                          'input_set': X_train, \n",
     "                          'label_set' : y_train, \n",
-    "                          'weight' : 0.05}, \n",
+    "                          'weight' : 0.1}, \n",
     "            'Random_Forest' : {'model': RF_clf, \n",
     "                          'input_set': X_train, \n",
     "                          'label_set' : y_train, \n",
-    "                          'weight' : .25}, \n",
-    "            'Gleason_LogReg' : {'model': Gleason_LR_clf, \n",
-    "                          'input_set': gleason_train, \n",
-    "                          'label_set' : y_train, \n",
     "                          'weight' : .2}, \n",
+    "            'LogReg' : {'model': LR_clf, \n",
+    "                          'input_set': logisticDF, \n",
+    "                          'label_set' : y_train, \n",
+    "                          'weight' : .35}, \n",
     "            'SVM' : {'model': SVM_clf, \n",
     "                          'input_set': XRFE_train, \n",
     "                          'label_set' : ypca_train, \n",
-    "                          'weight' : .25}, \n",
-    "            'LDA' : {'model': lda, \n",
-    "                          'input_set': X_train, \n",
-    "                          'label_set' : y_train, \n",
-    "                          'weight' : .2}}\n",
+    "                          'weight' : .35}}\n",
     "test_dict ={'AdaBoost' : {'model': ada_clf, \n",
     "                          'input_set': X_test, \n",
     "                          'label_set' : y_test, \n",
-    "                          'weight' : 0.05}, \n",
+    "                          'weight' : 0.1}, \n",
     "            'Random_Forest' : {'model': RF_clf, \n",
     "                          'input_set': X_test, \n",
     "                          'label_set' : y_test, \n",
-    "                          'weight' : .25}, \n",
-    "            'Gleason_LogReg' : {'model': Gleason_LR_clf, \n",
-    "                          'input_set': gleason_test, \n",
-    "                          'label_set' : y_test, \n",
     "                          'weight' : .2}, \n",
+    "            'LogReg' : {'model': LR_clf, \n",
+    "                          'input_set': logisticDF_test, \n",
+    "                          'label_set' : y_test, \n",
+    "                          'weight' : .35}, \n",
     "            'SVM' : {'model': SVM_clf, \n",
     "                          'input_set': XRFE_test, \n",
     "                          'label_set' : ypca_test, \n",
-    "                          'weight' : .25}, \n",
-    "            'LDA' : {'model': lda, \n",
-    "                          'input_set': X_test, \n",
-    "                          'label_set' : y_test, \n",
-    "                          'weight' : .2}}"
+    "                          'weight' : .35}}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 96,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                Gleason_LogReg  AdaBoost  Random_Forest  LDA   SVM  \\\n",
-      "clinical_index                                                       \n",
-      "TCGA-HC-7078               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-HI-7168               0.2      0.05           0.00  0.0  0.00   \n",
-      "TCGA-HC-A9TE               0.2      0.05           0.25  0.0  0.25   \n",
-      "TCGA-VP-A878               0.2      0.05           0.00  0.2  0.25   \n",
-      "TCGA-CH-5768               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-EJ-7792               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-CH-5788               0.0      0.00           0.00  0.2  0.25   \n",
-      "TCGA-EJ-A7NM               0.2      0.05           0.25  0.2  0.25   \n",
-      "TCGA-SU-A7E7               0.2      0.05           0.00  0.0  0.25   \n",
-      "TCGA-EJ-5504               0.0      0.00           0.00  0.0  0.00   \n",
-      "\n",
-      "                Weighted_Vote actual_y called_y  \n",
-      "clinical_index                                   \n",
-      "TCGA-HC-7078         0.000000       n0       n0  \n",
-      "TCGA-HI-7168         0.263158       n0       n0  \n",
-      "TCGA-HC-A9TE         0.789474       n0       n1  \n",
-      "TCGA-VP-A878         0.736842       n1       n1  \n",
-      "TCGA-CH-5768         0.000000       n0       n0  \n",
-      "TCGA-EJ-7792         0.000000       n0       n0  \n",
-      "TCGA-CH-5788         0.473684       n1       n0  \n",
-      "TCGA-EJ-A7NM         1.000000       n1       n1  \n",
-      "TCGA-SU-A7E7         0.526316       n0       n1  \n",
-      "TCGA-EJ-5504         0.000000       n1       n0  \n",
-      "\n",
-      "MCC:  0.669722379994\n",
-      "\n",
-      "F beta:  0.805084745763\n",
-      "\n",
-      "Class_report:\n",
-      "               precision    recall  f1-score   support\n",
-      "\n",
-      "         n0       0.97      0.89      0.92       287\n",
-      "         n1       0.63      0.86      0.73        66\n",
-      "\n",
-      "avg / total       0.90      0.88      0.89       353\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "def voter(clf_dict) :\n",
@@ -1182,27 +1018,24 @@
     "    for model in clf_dict.items() :\n",
     "        #print(model[0])\n",
     "        df[model[0]] = model[1]['model'].predict(model[1]['input_set'])\n",
-    "        index = model[1]['label_set'].index\n",
+    "        #index = model[1]['label_set'].index\n",
     "        df[model[0]].replace({'n1':1,'n0':0}, inplace = True)\n",
     "        df[model[0]] = df[model[0]].apply(lambda x : x*model[1]['weight'])\n",
     "        weights.append(model[1]['weight'])\n",
     "    df.set_index(clf_dict['SVM']['label_set'].index, inplace=True)\n",
     "    df['Weighted_Vote'] = df.apply(lambda x : sum(x)/np.sum(weights), axis = 1)\n",
     "    df['actual_y'] = list(clf_dict['SVM']['label_set'])\n",
-    "    df['called_y'] = df['Weighted_Vote'].apply(lambda x : x >= 0.50)\n",
+    "    df['called_y'] = df['Weighted_Vote'].apply(lambda x : x >= 0.6)\n",
     "    df['called_y'] = df['called_y'].replace({False : 'n0', True : 'n1'})\n",
     "    print(df.tail(10))\n",
     "    print('\\nMCC: ',matthews_corrcoef(df['actual_y'], df['called_y']))\n",
     "    print('\\nF beta: ',fbeta_score(df['actual_y'], df['called_y'], beta = 2, pos_label='n1'))\n",
-    "    print('\\nClass_report:\\n ',classification_report(df['actual_y'], df['called_y']))\n",
-    "\n",
-    "\n",
-    "voter(clf_dict)"
+    "    print('\\nClass_report:\\n ',classification_report(df['actual_y'], df['called_y']))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 97,
    "metadata": {
     "collapsed": false
    },
@@ -1211,43 +1044,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                Gleason_LogReg  AdaBoost  Random_Forest  LDA   SVM  \\\n",
-      "clinical_index                                                       \n",
-      "TCGA-HC-7078               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-HI-7168               0.2      0.05           0.00  0.0  0.00   \n",
-      "TCGA-HC-A9TE               0.2      0.05           0.25  0.0  0.25   \n",
-      "TCGA-VP-A878               0.2      0.05           0.00  0.2  0.25   \n",
-      "TCGA-CH-5768               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-EJ-7792               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-CH-5788               0.0      0.00           0.00  0.2  0.25   \n",
-      "TCGA-EJ-A7NM               0.2      0.05           0.25  0.2  0.25   \n",
-      "TCGA-SU-A7E7               0.2      0.05           0.00  0.0  0.25   \n",
-      "TCGA-EJ-5504               0.0      0.00           0.00  0.0  0.00   \n",
+      "                AdaBoost  Random_Forest  LogReg   SVM  Weighted_Vote actual_y  \\\n",
+      "clinical_index                                                                  \n",
+      "TCGA-HC-7078         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-HI-7168         0.1            0.0    0.00  0.00           0.10       n0   \n",
+      "TCGA-HC-A9TE         0.1            0.2    0.00  0.35           0.65       n0   \n",
+      "TCGA-VP-A878         0.1            0.0    0.35  0.35           0.80       n1   \n",
+      "TCGA-CH-5768         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-EJ-7792         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-CH-5788         0.0            0.0    0.35  0.35           0.70       n1   \n",
+      "TCGA-EJ-A7NM         0.1            0.2    0.35  0.35           1.00       n1   \n",
+      "TCGA-SU-A7E7         0.1            0.0    0.00  0.35           0.45       n0   \n",
+      "TCGA-EJ-5504         0.0            0.0    0.00  0.00           0.00       n1   \n",
       "\n",
-      "                Weighted_Vote actual_y called_y  \n",
-      "clinical_index                                   \n",
-      "TCGA-HC-7078         0.000000       n0       n0  \n",
-      "TCGA-HI-7168         0.263158       n0       n0  \n",
-      "TCGA-HC-A9TE         0.789474       n0       n1  \n",
-      "TCGA-VP-A878         0.736842       n1       n1  \n",
-      "TCGA-CH-5768         0.000000       n0       n0  \n",
-      "TCGA-EJ-7792         0.000000       n0       n0  \n",
-      "TCGA-CH-5788         0.473684       n1       n0  \n",
-      "TCGA-EJ-A7NM         1.000000       n1       n1  \n",
-      "TCGA-SU-A7E7         0.526316       n0       n1  \n",
-      "TCGA-EJ-5504         0.000000       n1       n0  \n",
+      "               called_y  \n",
+      "clinical_index           \n",
+      "TCGA-HC-7078         n0  \n",
+      "TCGA-HI-7168         n0  \n",
+      "TCGA-HC-A9TE         n1  \n",
+      "TCGA-VP-A878         n1  \n",
+      "TCGA-CH-5768         n0  \n",
+      "TCGA-EJ-7792         n0  \n",
+      "TCGA-CH-5788         n1  \n",
+      "TCGA-EJ-A7NM         n1  \n",
+      "TCGA-SU-A7E7         n0  \n",
+      "TCGA-EJ-5504         n0  \n",
       "\n",
-      "MCC:  0.669722379994\n",
+      "MCC:  0.791771275197\n",
       "\n",
-      "F beta:  0.805084745763\n",
+      "F beta:  0.867647058824\n",
       "\n",
       "Class_report:\n",
       "               precision    recall  f1-score   support\n",
       "\n",
-      "         n0       0.97      0.89      0.92       287\n",
-      "         n1       0.63      0.86      0.73        66\n",
+      "         n0       0.97      0.94      0.96       287\n",
+      "         n1       0.78      0.89      0.83        66\n",
       "\n",
-      "avg / total       0.90      0.88      0.89       353\n",
+      "avg / total       0.94      0.93      0.93       353\n",
       "\n"
      ]
     }
@@ -1258,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 89,
    "metadata": {
     "collapsed": false
    },
@@ -1267,43 +1100,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                Gleason_LogReg  AdaBoost  Random_Forest  LDA   SVM  \\\n",
-      "clinical_index                                                       \n",
-      "TCGA-CH-5765               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-EJ-7797               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-VN-A88Q               0.2      0.05           0.00  0.0  0.00   \n",
-      "TCGA-EJ-AB27               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-CH-5739               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-J4-AATZ               0.2      0.00           0.25  0.0  0.25   \n",
-      "TCGA-EJ-5502               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-J4-A67R               0.0      0.05           0.00  0.0  0.00   \n",
-      "TCGA-XK-AAJR               0.0      0.00           0.00  0.0  0.00   \n",
-      "TCGA-G9-A9S0               0.2      0.00           0.25  0.2  0.25   \n",
+      "                AdaBoost  Random_Forest  LogReg   SVM  Weighted_Vote actual_y  \\\n",
+      "clinical_index                                                                  \n",
+      "TCGA-CH-5765         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-EJ-7797         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-VN-A88Q         0.1            0.0    0.00  0.00           0.10       n0   \n",
+      "TCGA-EJ-AB27         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-CH-5739         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-J4-AATZ         0.0            0.2    0.00  0.35           0.55       n0   \n",
+      "TCGA-EJ-5502         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-J4-A67R         0.1            0.0    0.00  0.00           0.10       n0   \n",
+      "TCGA-XK-AAJR         0.0            0.0    0.00  0.00           0.00       n0   \n",
+      "TCGA-G9-A9S0         0.0            0.2    0.35  0.35           0.90       n1   \n",
       "\n",
-      "                Weighted_Vote actual_y called_y  \n",
-      "clinical_index                                   \n",
-      "TCGA-CH-5765         0.000000       n0       n0  \n",
-      "TCGA-EJ-7797         0.000000       n0       n0  \n",
-      "TCGA-VN-A88Q         0.263158       n0       n0  \n",
-      "TCGA-EJ-AB27         0.000000       n0       n0  \n",
-      "TCGA-CH-5739         0.000000       n0       n0  \n",
-      "TCGA-J4-AATZ         0.736842       n0       n1  \n",
-      "TCGA-EJ-5502         0.000000       n0       n0  \n",
-      "TCGA-J4-A67R         0.052632       n0       n0  \n",
-      "TCGA-XK-AAJR         0.000000       n0       n0  \n",
-      "TCGA-G9-A9S0         0.947368       n1       n1  \n",
+      "               called_y  \n",
+      "clinical_index           \n",
+      "TCGA-CH-5765         n0  \n",
+      "TCGA-EJ-7797         n0  \n",
+      "TCGA-VN-A88Q         n0  \n",
+      "TCGA-EJ-AB27         n0  \n",
+      "TCGA-CH-5739         n0  \n",
+      "TCGA-J4-AATZ         n0  \n",
+      "TCGA-EJ-5502         n0  \n",
+      "TCGA-J4-A67R         n0  \n",
+      "TCGA-XK-AAJR         n0  \n",
+      "TCGA-G9-A9S0         n1  \n",
       "\n",
-      "MCC:  0.647115664966\n",
+      "MCC:  0.623342175066\n",
       "\n",
-      "F beta:  0.746268656716\n",
+      "F beta:  0.692307692308\n",
       "\n",
       "Class_report:\n",
       "               precision    recall  f1-score   support\n",
       "\n",
-      "         n0       0.95      0.91      0.93        58\n",
-      "         n1       0.67      0.77      0.71        13\n",
+      "         n0       0.93      0.93      0.93        58\n",
+      "         n1       0.69      0.69      0.69        13\n",
       "\n",
-      "avg / total       0.90      0.89      0.89        71\n",
+      "avg / total       0.89      0.89      0.89        71\n",
       "\n"
      ]
     }

--- a/RFE_SVM/RFECV_SVM.py
+++ b/RFE_SVM/RFECV_SVM.py
@@ -3,7 +3,7 @@ from sklearn.svm import SVC
 
 estimator = SVC(C= .5,
                 kernel='linear',
-                probability=False,
+                probability=True,
                 tol=0.001,
                 gamma = 'auto',
                 cache_size=200,
@@ -14,7 +14,7 @@ estimator = SVC(C= .5,
 selector = RFECV(estimator,
                  step = 5,
                  cv = 5,
-                scoring = fbeta_scorer)
+                 scoring = fbeta_scorer)
 selector.fit(Xpca_train, ypca_train)
 
 print(classification_report(ypca_train,


### PR DESCRIPTION
Use LDA to compress data set and allow logistic regression to train on this data, alongside gleason score.  Update downstream predictions to reflect changes in annotation. 
